### PR TITLE
Restore panel after successful request

### DIFF
--- a/src/main/resources/static/js/nexus-artifact-usage-plugin-all.js
+++ b/src/main/resources/static/js/nexus-artifact-usage-plugin-all.js
@@ -168,6 +168,7 @@ Ext
 								callback : function(options, isSuccess,
 										response) {
 									if (isSuccess) {
+										artifactContainer.showTab(this);
 										var infoResp = Ext
 												.decode(response.responseText);
 										this


### PR DESCRIPTION
Sometimes, if the panel blows up, it only re appears when you reload the whole page.
thanks to this fix, clickong on another artifact will make the panel reappear
